### PR TITLE
Fix A2168 - General failure using 64-bit MSVC

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -69,7 +69,7 @@ int main( int argc, char **argv )
     /* v2.11: _findfirst/next/close() handle, should be of type intptr_t.
      * since this type isn't necessarily defined, type long is used as substitute.
      */
-    long    fh;
+    intptr_t fh;
     const char *pfn;
     int     dirsize;
     struct  _finddata_t finfo;

--- a/src/parser.c
+++ b/src/parser.c
@@ -2924,6 +2924,7 @@ ret_code ParseLine( struct asm_tok tokenarray[] )
               Token_Count, GetCurrOffset() ));
 
     i = 0;
+    oldofs = 0;
 
     /* Does line start with a code label? */
     if ( tokenarray[0].token == T_ID && ( tokenarray[1].token == T_COLON || tokenarray[1].token == T_DBL_COLON ) ) {


### PR DESCRIPTION
When assembling this file called **lin64_1.asm**:
```
;--- "hello world" for 64-bit Linux, using SYSCALL.
;--- assemble: JWasm -elf64 -Fo=Lin64_1.o Lin64_1.asm
;--- link:     gcc Lin64_1.o -o Lin64_1

stdout    equ 1
SYS_WRITE equ 1
SYS_EXIT  equ 60

    .data

string  db 10,"Hello, world!",10

    .code

_start:
    mov edx, sizeof string
    mov rsi, offset string
    mov edi, stdout
    mov eax, SYS_WRITE
    syscall
    mov eax, SYS_EXIT
    syscall

    end _start
```
using the command:
```
jwasm.exe -elf64 -Fo=lin64_1.o lin64_1.asm
```
jwasm of current master fails with the following message:
```
JWasm v2.15pre, Jan 21 2021, Masm-compatible assembler.
Portions Copyright (c) 1992-2002 Sybase, Inc. All Rights Reserved.
Source code is available under the Sybase Open Watcom Public License.

C:\Users\maarten\source\repos\conan-center-index\recipes\jwasm\all\test_package\Lin64_1.asm: 24 lines, 2 passes, 2 ms, 0 warnings, 0 errors
Error A2168: General Failure
```

With the patch of this pr, the message becomes:
```
JWasm v2.15pre, Jan 21 2021, Masm-compatible assembler.
Portions Copyright (c) 1992-2002 Sybase, Inc. All Rights Reserved.
Source code is available under the Sybase Open Watcom Public License.

C:\Users\maarten\source\repos\conan-center-index\recipes\jwasm\all\test_package\Lin64_1.asm: 24 lines, 2 passes, 3 ms, 0 warnings, 0 errors
```


FYI:
We detected this problem while trying to add a jwasm to [conan-center-index](https://conan.io/center/) at https://github.com/conan-io/conan-center-index/pull/4321.
The first version of the build recipe is to use jwasm at https://github.com/JWasm/JWasm, but that fork is stale.
Can you comment on the relation between this fork and the other?

The other fork uses cmake, is there any reason that isn't used here?
We, at conan-center, kinda like cmake because it lets us build packages uniformly on all platform.
When using cmake, there is only one unified build script and no need to use multiple make script with each script having its issues.