### PR TITLE
fix: do not try to assemble file named by $JWASM / %JWASM% variable

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -105,7 +105,7 @@ int main( int argc, char **argv )
 #endif
 
     /* ParseCmdLine() returns NULL if no source file name has been found (anymore) */
-    while ( ParseCmdline( (const char **)argv, &numArgs ) ) {
+    while ( ParseCmdline( (const char **)argv + 1, &numArgs ) ) {
         numFiles++;
         write_logo();
 #if WILDCARDS


### PR DESCRIPTION
If the variable named `JWASM` was set, jwasm (both DOS32/DJGPP and Linux) would parse the contents of that variable as a command line parameter. For example,

```
edrdos/repo/drbio$ JWASM=FOO jwasm -c -Zm -Fo./bin/initmsgs initmsgs.asm
JWasm v2.18, Aug 14 2023, Masm-compatible assembler.
Portions Copyright (c) 1992-2002 Sybase, Inc. All Rights Reserved.
Source code is available under the Sybase Open Watcom Public License.

Fatal error A1106: Cannot open file: "FOO" [ENOENT]
initmsgs.asm: 93 lines, 2 passes, 0 ms, 0 warnings, 0 errors
```

This code is responsible for filling `argv[0]`: https://github.com/Baron-von-Riedesel/JWasm/blob/dbeeaf631bfdc70bf444d156325cf3a73702c97f/src/main.c#L92

The error became apparent because the assembler spammed a lot of messages when trying to replace the use of MASM in the EDR-DOS build by JWasm. They were caused by setting `set JWASM=C:\BIN\JWASM.EXE` and JWasm trying to parse its executable file as an assembly source file then.