### PR TITLE
ecm patch: in listing file mark relocations using square brackets

### DIFF
--- a/src/H/globals.h
+++ b/src/H/globals.h
@@ -871,4 +871,7 @@ extern char             *myltoa( uint_32 value, char *buffer, unsigned radix, bo
 extern char             *ConvertSectionName( const struct asym *, enum seg_type *pst, char *buffer );
 #endif
 
+extern unsigned IsFixup( struct dsym *curr, void* isfixup_pointer );
+
 #endif
+


### PR DESCRIPTION
This is for use by my (ecm's) TracList utility. There is a conversion script intended to process the Debug/X listing file. This patch is needed for TracList to be able to match instructions that contain relocations. Even in -bin mode JWasm does not emit the final relocated data to the listing file. Therefore, with this patch the bytes dumped for to-be-relocated addresses are surrounded by square brackets.

Reference: https://hg.pushbx.org/ecm/tractest/rev/d626eea3a5bb