### PR TITLE
Fix include guard in types.h

### DIFF
--- a/src/H/types.h
+++ b/src/H/types.h
@@ -1,7 +1,7 @@
 
 /* prototypes of TYPES.C */
 
-#ifndef _TYPES_H_INCLUDED
+#ifndef _TYPES_H_INCLUDED_
 #define _TYPES_H_INCLUDED_
 
 /* qualified_type us used for parsing a qualified type. */


### PR DESCRIPTION
As warned by recent clang:

```
In file included from src/assume.c:38:
src/H/types.h:4:9: warning: '_TYPES_H_INCLUDED' is used as a header guard here, followed by #define of a different macro [-Wheader-guard]
    4 | #ifndef _TYPES_H_INCLUDED
      |         ^~~~~~~~~~~~~~~~~
src/H/types.h:5:9: note: '_TYPES_H_INCLUDED_' is defined here; did you mean '_TYPES_H_INCLUDED'?
    5 | #define _TYPES_H_INCLUDED_
      |         ^~~~~~~~~~~~~~~~~~
      |         _TYPES_H_INCLUDED
```