### PR TITLE
add DragonFlyBSD, OpenBSD support

### DIFF
--- a/GccUnix.mak
+++ b/GccUnix.mak
@@ -21,7 +21,7 @@ endif
 
 c_flags =-D__UNIX__ $(extra_c_flags)
 
-CC = gcc
+CC ?= cc
 
 .SUFFIXES:
 .SUFFIXES: .c .o

--- a/src/H/memalloc.h
+++ b/src/H/memalloc.h
@@ -45,7 +45,7 @@ extern void MemFree( void *ptr );
 #elif defined(__GNUC__) || defined(__TINYC__)
 
 #define myalloca  alloca
-#ifndef __FreeBSD__  /* added v2.08 */
+#if !(defined(__FreeBSD__) || defined(__DragonFly__) || defined(__OpenBSD__))
 #include <malloc.h>  /* added v2.07 */
 #endif
 


### PR DESCRIPTION
and OpenBSD/FreeBSD default compiler is clang, replace gcc -> cc for GccUnix.mak.
If gcc is needed, `CC=gcc gmake -f GccUnix.make` can do it.