### PR TITLE
add missing includes

### DIFF
--- a/src/H/globals.h
+++ b/src/H/globals.h
@@ -39,6 +39,7 @@
 
 #if defined(__UNIX__) || defined(__CYGWIN__) || defined(__DJGPP__) /* avoid for MinGW! */
 
+#include <strings.h>
 #define _stricmp strcasecmp
 #ifndef __WATCOMC__
 #define _memicmp strncasecmp

--- a/src/H/memalloc.h
+++ b/src/H/memalloc.h
@@ -44,6 +44,7 @@ extern void MemFree( void *ptr );
 
 #elif defined(__GNUC__) || defined(__TINYC__)
 
+#include <alloca.h>
 #define myalloca  alloca
 #ifndef __FreeBSD__  /* added v2.08 */
 #include <malloc.h>  /* added v2.07 */

--- a/src/omf.c
+++ b/src/omf.c
@@ -62,6 +62,7 @@
 
 #if TRUNCATE
 #if defined(__UNIX__) || defined(__CYGWIN__) || defined(__DJGPP__)
+#include <stdio.h>
 #include <unistd.h>
 #else
 #include <io.h>


### PR DESCRIPTION
Several includes are missing based on linux man pages:

- strings.h for `strcasecmp`
- alloca.h  for `alloca`
- stdio.h   for `fileno`

The compilation with GCC 15 fails without those with implicit function declaration error.

---

It is also worth to say that GCC 15 defaults to `-std=c23`, where `bool` is a reserved keyword, thus GCC produces following error:
```
src/H/bool.h:35:27: error: two or more data types in declaration specifiers
   35 |     typedef unsigned char bool;
      |                           ^~~~
```
I am using `-std=c17` for now.